### PR TITLE
add blobstorage pathname parameter

### DIFF
--- a/src/org/citybot/ant/AzureBlobFileUpload.java
+++ b/src/org/citybot/ant/AzureBlobFileUpload.java
@@ -54,7 +54,7 @@ public class AzureBlobFileUpload extends Task {
 	}
 	public void addFileset(FileSet fileset) {
         filesets.add(fileset);
-    }
+    	}
 
 	public String getBlobPath() {
 		return blobPath;

--- a/src/org/citybot/ant/AzureBlobFileUpload.java
+++ b/src/org/citybot/ant/AzureBlobFileUpload.java
@@ -28,6 +28,7 @@ public class AzureBlobFileUpload extends Task {
 	String container;
 	String account;
 	String key;
+	String blobPath;
 	String protocol = "http";
 	private Vector filesets = new Vector();
 	Boolean create = true;
@@ -54,6 +55,14 @@ public class AzureBlobFileUpload extends Task {
 	public void addFileset(FileSet fileset) {
         filesets.add(fileset);
     }
+
+	public String getBlobPath() {
+		return blobPath;
+	}
+	public void setBlobPath(String blobPath) {
+		this.blobPath = blobPath;
+	}
+	
 	public void execute() {
         if (container==null) {
             throw new BuildException("Property 'container' is required");
@@ -67,6 +76,10 @@ public class AzureBlobFileUpload extends Task {
         if(filesets.isEmpty()) {
         	throw new BuildException("A nested 'fileset' is required");
         }
+        if (blobPath==null) {
+        	blobPath = "";
+        }        
+        
         try {
         	String storageConnectionString = String.format("DefaultEndpointsProtocol=%s;AccountName=%s;AccountKey=%s", protocol, account, key);
 			CloudStorageAccount storageAccount = CloudStorageAccount.parse(storageConnectionString);
@@ -92,6 +105,9 @@ public class AzureBlobFileUpload extends Task {
 		        	String filename = includedFiles[i].replace('\\','/');
 		        	File source = new File(ds.getBasedir() + "/" + filename);
 		        	String blobname = filename.substring(filename.lastIndexOf("/")+1);
+		        	if(blobPath!=null){
+		        		blobname = blobPath + File.pathSeparator + blobname;
+		        	}
 	                CloudBlockBlob blobHandle = blobContainer.getBlockBlobReference(blobname);
 	                blobHandle.upload(new FileInputStream(source), source.length());
 		        }


### PR DESCRIPTION
If you want to display the path to the remote repository , the user can add the path to the remote storage as follows .

export AZURE_STORAGE_ACCOUNT=<storage_account_name>
export AZURE_STORAGE_ACCESS_KEY=<storage_account_key>

export container_name=<container_name>
export blob_name=<blob_name>
export image_to_upload=<image_to_upload>
export destination_folder=<destination_folder>

I made a parameter(blobpath) is to specify a "destination_folder".
